### PR TITLE
Potential fix for code scanning alert no. 4: Server-side request forgery

### DIFF
--- a/code/server.js
+++ b/code/server.js
@@ -117,6 +117,11 @@ app.prepare().then(() => {
             console.info('GeoServer requests from MapBox will be sent to ' + process.env.REACT_APP_SERVER_URL + '/geoserver-proxy')
             server.get('/geoserver-proxy', keycloak.protect(), async (req, res) => {
                 const targetUrl = req.query.url;
+                const allowedUrls = [
+                    'https://example.com/geoserver',
+                    'https://another-allowed-url.com/geoserver'
+                ];
+
                 let headers = { ...req.headers };
 
                 if (req.kauth?.grant) {
@@ -124,6 +129,11 @@ app.prepare().then(() => {
                 }
 
                 try {
+                    // Validate the target URL against the allowed list
+                    if (!allowedUrls.includes(targetUrl)) {
+                        return res.status(400).send('Invalid URL');
+                    }
+
                     // Forward the request to the target URL with the modified headers
                     const response = await axios({
                         url: targetUrl,


### PR DESCRIPTION
Potential fix for [https://github.com/TheWorldAvatar/viz/security/code-scanning/4](https://github.com/TheWorldAvatar/viz/security/code-scanning/4)

To fix the problem, we need to ensure that the `targetUrl` is validated against a whitelist of allowed URLs or domains. This will prevent an attacker from specifying arbitrary URLs and potentially accessing internal services or other unintended resources.

The best way to fix this is to:
1. Define a list of allowed base URLs or domains.
2. Validate the `targetUrl` against this list before making the request.
3. Reject or sanitize any input that does not match the allowed list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
