### PR TITLE
Potential fix for code scanning alert no. 3: Clear text transmission of sensitive cookie

### DIFF
--- a/code/server.js
+++ b/code/server.js
@@ -88,6 +88,10 @@ app.prepare().then(() => {
                 resave: false,
                 saveUninitialized: true,
                 store: store,
+                cookie: {
+                    secure: !dev, // Set secure attribute to true in production
+                    httpOnly: true, // Prevent client-side scripts from accessing the cookie
+                },
             })
         );
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheWorldAvatar/viz/security/code-scanning/3](https://github.com/TheWorldAvatar/viz/security/code-scanning/3)

To fix the problem, we need to ensure that the session cookie is only transmitted over secure connections by setting the `secure` attribute to `true`. This can be done by modifying the session configuration to include the `secure` attribute. Additionally, we should set the `httpOnly` attribute to prevent client-side scripts from accessing the cookie, further enhancing security.

- Modify the session configuration in the `server.use(session({...` block to include the `secure` and `httpOnly` attributes.
- Ensure that the `secure` attribute is conditionally set based on the environment (e.g., only set to `true` in production).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
