### PR TITLE
expand parameters in FIA request

### DIFF
--- a/code/src/ui/interaction/tree/floating-panel.tsx
+++ b/code/src/ui/interaction/tree/floating-panel.tsx
@@ -8,7 +8,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { DataStore } from 'io/data/data-store';
 import { selectDimensionSliderValue } from 'state/dimension-slider-slice';
 import { getIndex, setIndex } from 'state/floating-panel-slice';
-import { getFeatures, getFilterTimes, getIri, getProperties, getScenarioID, getStack, MapFeaturePayload } from 'state/map-feature-slice';
+import { getFeatures, getIri, getProperties, getScenarioID, getStack, MapFeaturePayload } from 'state/map-feature-slice';
 import { Dictionary } from 'types/dictionary';
 import { MapLayerGroup } from 'types/map-layer';
 import { IconSettings, LegendSettings } from 'types/settings';
@@ -52,7 +52,6 @@ export default function FloatingPanelContainer(
   const selectedStack = useSelector(getStack);
   const selectedScenario = useSelector(getScenarioID);
   const availableFeatures: MapFeaturePayload[] = useSelector(getFeatures);
-  const filterTimes: number[] = useSelector(getFilterTimes);
   //TODO fetch from api
   const buttonClass = styles.headButton;
   const buttonClassActive = [styles.headButton, styles.active].join(" ");
@@ -60,7 +59,7 @@ export default function FloatingPanelContainer(
   const hasMultipleDimensions = Object.values(props.scenarioDimensions).some(array => array.length > 1);
   // Execute API call
   const { attributes, timeSeries, isFetching, isUpdating } = useFeatureInfoAgentService(
-    generateFIAEndpoint(selectedIri, selectedStack, selectedScenario, filterTimes, ...(hasMultipleDimensions ? [dimensionSliderValue] : [])),
+    generateFIAEndpoint(selectedIri, selectedStack, selectedScenario, selectedProperties, ...(hasMultipleDimensions ? [dimensionSliderValue] : [])),
     selectedIri,
     selectedProperties
   );

--- a/code/src/utils/data-services.ts
+++ b/code/src/utils/data-services.ts
@@ -25,14 +25,12 @@ const stackKey: string = "stack";
  * @param {string} stack The stack endpoint associated with the target feature.
  * @param {string} scenario The current scenario ID (if any).
 */
-export function generateFIAEndpoint(iri: string, stack: string, scenario: string, filterTimes: number[], dimensionSliderValue?: number[] | number): string {
-  let url = `${stack}/feature-info-agent/get?iri=${encodeURIComponent(iri)}`;
+export function generateFIAEndpoint(iri: string, stack: string, scenario: string, properties: object, dimensionSliderValue?: number[] | number): string {
+  let url = `${stack}/feature-info-agent/get`;
 
-  // this is only used for trajectory queries, not the actual time series data
-  if (filterTimes && filterTimes.length === 2) {
-    url += `&lowerbound=${filterTimes[0]}`;
-    url += `&upperbound=${filterTimes[1]}`;
-  }
+  let params = { iri, ...properties };
+  let queryString = new URLSearchParams(params).toString();
+  url = `${url}?${queryString}`;
 
   if (scenario && stack && iri) {
     url = `${stack}/CReDoAccessAgent/getMetadataPrivate/${scenario}?iri=${encodeURIComponent(iri)}`;


### PR DESCRIPTION
Append all parameters from the GeoServer layer onto the request to the feature info agent. This also reenables an old feature from the old framework to enforce a query endpoint instead of a federated query