### PR TITLE
Ctlao/656 deduplicate refresh

### DIFF
--- a/code/src/hooks/table/api/useTableData.tsx
+++ b/code/src/hooks/table/api/useTableData.tsx
@@ -54,10 +54,17 @@ export function useTableData(
   const [data, setData] = useState<FieldValues[]>([]);
   const [columns, setColumns] = useState<EnhancedColumnDef<FieldValues>[]>([]);
 
-  const isInitialLoad = useRef(true);
+  const [prevFlag, setPrevFlag] = useState(refreshFlag);
 
   // A hook that refetches all data when the dialogs are closed
   useEffect(() => {
+
+    // Check if refreshFlag is going from true to false, if so, skip fetching data
+    const isResetting = prevFlag === true && refreshFlag === false;
+    setPrevFlag(refreshFlag); // Sync for next time
+
+    if (isResetting) return;
+
     const fetchData = async (): Promise<void> => {
       setIsLoading(true);
       const filterParams: string = parseColumnFiltersIntoUrlParams(filters, dict.title.blank, dict.title);
@@ -142,12 +149,7 @@ export function useTableData(
       }
     };
 
-    if (isInitialLoad.current || refreshFlag) {
-      // fetch data when the component first mounts or when refreshFlag is true
-      fetchData();
-      // After the first run, set the ref to false forever
-      isInitialLoad.current = false;
-    }
+    fetchData();
 
   }, [selectedDate, refreshFlag, apiPagination, sortParams, filters, columnOptions, entityType]);
 

--- a/code/src/hooks/table/api/useTableData.tsx
+++ b/code/src/hooks/table/api/useTableData.tsx
@@ -1,6 +1,6 @@
 import { ColumnFilter, PaginationState, SortingState } from "@tanstack/react-table";
 import { useDictionary } from "hooks/useDictionary";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { DateRange } from "react-day-picker";
 import { FieldValues } from "react-hook-form";
 import { AgentResponseBody, InternalApiIdentifierMap } from "types/backend-agent";
@@ -53,6 +53,9 @@ export function useTableData(
   const [totalCount, setTotalCount] = useState<number>(0);
   const [data, setData] = useState<FieldValues[]>([]);
   const [columns, setColumns] = useState<EnhancedColumnDef<FieldValues>[]>([]);
+
+  const isInitialLoad = useRef(true);
+
   // A hook that refetches all data when the dialogs are closed
   useEffect(() => {
     const fetchData = async (): Promise<void> => {
@@ -139,7 +142,13 @@ export function useTableData(
       }
     };
 
-    fetchData();
+    if (isInitialLoad.current || refreshFlag) {
+      // fetch data when the component first mounts or when refreshFlag is true
+      fetchData();
+      // After the first run, set the ref to false forever
+      isInitialLoad.current = false;
+    }
+
   }, [selectedDate, refreshFlag, apiPagination, sortParams, filters, columnOptions, entityType]);
 
   return {


### PR DESCRIPTION
Previously the refresh table hook is triggered twice every refresh.

It now tracks the previous status of refresh flag and skip fetching data if the refresh flag is being reset from true to false.

It should behave exactly as before for all other triggering conditions.